### PR TITLE
Add property to PCIDevice called "domain"

### DIFF
--- a/hw/pci/pci.c
+++ b/hw/pci/pci.c
@@ -59,6 +59,7 @@ static char *pcibus_get_fw_dev_path(DeviceState *dev);
 static void pcibus_reset(BusState *qbus);
 
 static Property pci_props[] = {
+    DEFINE_PROP_UINT16("domain", PCIDevice, domain, 0),
     DEFINE_PROP_PCI_DEVFN("addr", PCIDevice, devfn, -1),
     DEFINE_PROP_STRING("romfile", PCIDevice, romfile),
     DEFINE_PROP_UINT32("rombar",  PCIDevice, rom_bar, 1),

--- a/include/hw/pci/pci.h
+++ b/include/hw/pci/pci.h
@@ -281,6 +281,9 @@ struct PCIDevice {
     /* Used to allocate config space for capabilities. */
     uint8_t *used;
 
+    /* Specify the domain it belongs to */
+    uint16_t domain;
+
     /* the following fields are read only */
     int32_t devfn;
     /* Cached device to fetch requester ID from, to avoid the PCI


### PR DESCRIPTION
@mcastelino  I quickly tried this with dirty codes and it helps identify which domain to hotplug on.
Later, when we change s->pcihp_state to link list, the switch/case can be cleanly changed to a simple loop.
